### PR TITLE
Icon을 CreateDom 함수로 생성할 때 오류 해결

### DIFF
--- a/client/jsconfig.json
+++ b/client/jsconfig.json
@@ -3,13 +3,14 @@
         "checkJs": false,
         "baseUrl": "./src",
         "paths": {
-            "@src/*": ["./*"],
             "@apis/*": ["./apis/*"],
             "@components/*": ["./components/*"],
             "@core/*": ["./core/*"],
+            "@icons/*": ["./icons/*"],
             "@pages/*": ["./pages/*"],
             "@store/*": ["./store/*"],
-            "@utils/*": ["./utils/*"]
+            "@utils/*": ["./utils/*"],
+            "@src/*": ["./*"]
         },
         "moduleResolution": "node"
     },

--- a/client/src/GlobalStyle.css
+++ b/client/src/GlobalStyle.css
@@ -1,3 +1,7 @@
+* {
+    box-sizing: border-box;
+}
+
 html {
     --color-Title_Active: #1e2222;
     --color-Body: #626666;
@@ -110,10 +114,6 @@ video {
 ol,
 ul {
     list-style: none;
-}
-
-* {
-    box-sizing: border-box;
 }
 
 body {

--- a/client/src/icons/calendar.js
+++ b/client/src/icons/calendar.js
@@ -1,19 +1,14 @@
-import { svg } from "@core/CreateDom";
+import { svgDomCreator } from "@utils/svgDomCreator";
 
-const calendarIcon = (color = "#222222") => {
-    return svg({
-        xmlns: "http://www.w3.org/2000/svg",
-        width: "24",
-        height: "24",
-        viewBox: "0 0 24 24",
-        fill: "none",
-        innerHTML: `
+const calendarIcon = (color = "#222222", width = 24, height = 24) => {
+    return svgDomCreator(`
+        <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 24 24" fill="none">
             <path d="M19 4H5C3.89543 4 3 4.89543 3 6V20C3 21.1046 3.89543 22 5 22H19C20.1046 22 21 21.1046 21 20V6C21 4.89543 20.1046 4 19 4Z" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M16 2V6" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M8 2V6" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M3 10H21" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        `,
-    })();
+        </svg>
+    `);
 };
 
 export default calendarIcon;

--- a/client/src/icons/calendar.js
+++ b/client/src/icons/calendar.js
@@ -1,4 +1,4 @@
-import { svgDomCreator } from "@utils/svgDomCreator";
+import svgDomCreator from "@utils/svgDomCreator";
 
 const calendarIcon = (color = "#222222", width = 24, height = 24) => {
     return svgDomCreator(`

--- a/client/src/icons/chart.js
+++ b/client/src/icons/chart.js
@@ -1,18 +1,13 @@
-import { svg } from "@core/CreateDom";
+import { svgDomCreator } from "@utils/svgDomCreator";
 
-const chartIcon = (color = "#222222") => {
-    return svg({
-        xmlns: "http://www.w3.org/2000/svg",
-        width: "24",
-        height: "24",
-        viewBox: "0 0 24 24",
-        fill: "none",
-        innerHTML: `
-        <path d="M18 20V10" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M12 20V4" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M6 20V14" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        `,
-    })();
+const chartIcon = (color = "#222222", width = 24, height = 24) => {
+    return svgDomCreator(`
+        <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 24 24" fill="none">
+            <path d="M18 20V10" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M12 20V4" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M6 20V14" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+    `);
 };
 
 export default chartIcon;

--- a/client/src/icons/chart.js
+++ b/client/src/icons/chart.js
@@ -1,4 +1,4 @@
-import { svgDomCreator } from "@utils/svgDomCreator";
+import svgDomCreator from "@utils/svgDomCreator";
 
 const chartIcon = (color = "#222222", width = 24, height = 24) => {
     return svgDomCreator(`

--- a/client/src/icons/check.js
+++ b/client/src/icons/check.js
@@ -1,16 +1,11 @@
-import { svg } from "@core/CreateDom";
+import { svgDomCreator } from "@utils/svgDomCreator";
 
-const checkIcon = (color = "#222222") => {
-    return svg({
-        xmlns: "http://www.w3.org/2000/svg",
-        width: "24",
-        height: "24",
-        viewBox: "0 0 24 24",
-        fill: "none",
-        innerHTML: `
+const checkIcon = (color = "#222222", width = 24, height = 24) => {
+    return svgDomCreator(`
+        <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 24 24" fill="none">
             <path d="M21 6L8.625 18L3 12.5455" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        `,
-    })();
+        </svg>
+    `);
 };
 
 export default checkIcon;

--- a/client/src/icons/check.js
+++ b/client/src/icons/check.js
@@ -1,4 +1,4 @@
-import { svgDomCreator } from "@utils/svgDomCreator";
+import svgDomCreator from "@utils/svgDomCreator";
 
 const checkIcon = (color = "#222222", width = 24, height = 24) => {
     return svgDomCreator(`

--- a/client/src/icons/downArrow.js
+++ b/client/src/icons/downArrow.js
@@ -1,4 +1,4 @@
-import { svgDomCreator } from "@utils/svgDomCreator";
+import svgDomCreator from "@utils/svgDomCreator";
 
 const downArrowIcon = (color = "#8D9393", width = 16, height = 17) => {
     return svgDomCreator(`

--- a/client/src/icons/downArrow.js
+++ b/client/src/icons/downArrow.js
@@ -1,6 +1,6 @@
 import { svgDomCreator } from "@utils/svgDomCreator";
 
-const downArrow = (color = "#8D9393", width = 16, height = 17) => {
+const downArrowIcon = (color = "#8D9393", width = 16, height = 17) => {
     return svgDomCreator(`
         <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 16 17" fill="none">
             <path d="M4 6.5L8 10.5L12 6.5" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -8,4 +8,4 @@ const downArrow = (color = "#8D9393", width = 16, height = 17) => {
     `);
 };
 
-export default downArrow;
+export default downArrowIcon;

--- a/client/src/icons/downArrow.js
+++ b/client/src/icons/downArrow.js
@@ -1,0 +1,11 @@
+import { svgDomCreator } from "@utils/svgDomCreator";
+
+const downArrow = (color = "#8D9393", width = 16, height = 17) => {
+    return svgDomCreator(`
+        <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 16 17" fill="none">
+            <path d="M4 6.5L8 10.5L12 6.5" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+    `);
+};
+
+export default downArrow;

--- a/client/src/icons/fileText.js
+++ b/client/src/icons/fileText.js
@@ -1,4 +1,4 @@
-import { svgDomCreator } from "@utils/svgDomCreator";
+import svgDomCreator from "@utils/svgDomCreator";
 
 const fileTextIcon = (color = "#222222", width = 24, height = 24) => {
     return svgDomCreator(`

--- a/client/src/icons/fileText.js
+++ b/client/src/icons/fileText.js
@@ -1,20 +1,15 @@
-import { svg } from "@core/CreateDom";
+import { svgDomCreator } from "@utils/svgDomCreator";
 
-const fileTextIcon = (color = "#222222") => {
-    return svg({
-        xmlns: "http://www.w3.org/2000/svg",
-        width: "24",
-        height: "24",
-        viewBox: "0 0 24 24",
-        fill: "none",
-        innerHTML: `
+const fileTextIcon = (color = "#222222", width = 24, height = 24) => {
+    return svgDomCreator(`
+        <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 24 24" fill="none">
             <path d="M14 2H6C5.46957 2 4.96086 2.21071 4.58579 2.58579C4.21071 2.96086 4 3.46957 4 4V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V8L14 2Z" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M14 2V8H20" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M16 13H8" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M16 17H8" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M10 9H9H8" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        `,
-    })();
+        </svg>
+    `);
 };
 
 export default fileTextIcon;

--- a/client/src/icons/index.js
+++ b/client/src/icons/index.js
@@ -1,0 +1,7 @@
+import fileTextIcon from "@icons/fileText";
+import calendarIcon from "@icons/calendar";
+import chartIcon from "@icons/chart";
+import checkIcon from "@icons/check";
+import downArrowIcon from "@icons/downArrow";
+
+export { fileTextIcon, calendarIcon, chartIcon, checkIcon, downArrowIcon };

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,3 +1,4 @@
 import App from "@src/App";
+import "@src/GlobalStyle.css";
 
 document.body.appendChild(new App());

--- a/client/src/utils/svgDomCreator.js
+++ b/client/src/utils/svgDomCreator.js
@@ -1,0 +1,17 @@
+import { div } from "@core/CreateDom";
+
+/**
+ * SVG 생성 시 createElementNS 형식으로 xmlns 에 맞춰주도록 생성해야 합니다.
+ * 다른 Element와는 특별한 케이스이기 때문에
+ * innerHTML 로 자동 생성되는 Dom 을 이용해 SVG 를 생성하도록 합니다.
+ * @param {*} string parser
+ * @returns {SVGElement}  SVG DOM Element
+ */
+const svgDomCreator = (string) => {
+    const tempDom = div();
+    tempDom.innerHTML = string;
+    const iconDom = tempDom.children[0];
+    return iconDom;
+};
+
+export default svgDomCreator;


### PR DESCRIPTION
## 이슈번호
- #21

<!-- 참고용, 팁, 출처, 스크린샷 -->
## 참고사항

- `svg` 의 `xmlns` 속성이 정해져 있으므로 `createElementNS` 함수를 통해 형식 지정으로 엘리먼트를 생성해야 합니다.
    - `CreateDom` 함수 같은 경우 `svg`와 `path` 를 제외하고 `createElement` 를 통해 엘리먼트를 생성하고 있습니다.
    - 다른 Element의 비교 로직을 늘리는 것보다, 따로 사용하는 것이 좋을 것 같은 판단 하에 util 함수에서 이를 생성하도록 분리했습니다.
    - `svgDomCreator` 함수는 `innerHTML` 속성 변경을 통해 `svg` 엘리먼트를 생성하여 반환합니다. 


