### PR TITLE
꺾은 선 그래프 라벨 텍스트 위치 계산 및 스타일 변경 

### DIFF
--- a/client/src/components/Statistic/LineChart/index.js
+++ b/client/src/components/Statistic/LineChart/index.js
@@ -164,7 +164,7 @@ export default class LineChart extends Component {
     }
 
     drawMonthsText() {
-        const COLOR_PRIMARY = ROOT_STYLE.getPropertyValue("--color-Primary");
+        const COLOR_CATEGORY = categories.getCategoryColorById(recentSum.state.category);
         const COLOR_LABEL = ROOT_STYLE.getPropertyValue("--color-Label");
 
         const { minX, termX, maxY } = this.measurement;
@@ -175,7 +175,7 @@ export default class LineChart extends Component {
         months.forEach((targetMonth, i) => {
             const curX = i * termX * MONTH_COLUMN;
             const isToday = this.isIndexToday(i);
-            const color = isToday ? COLOR_PRIMARY : COLOR_LABEL;
+            const color = isToday ? COLOR_CATEGORY : COLOR_LABEL;
             this.drawText(targetMonth, minX + curX, labelHeight, color, isToday);
         });
     }


### PR DESCRIPTION
## 이슈번호
- #49 

<!-- 참고용, 팁, 출처, 스크린샷 -->
<img width="950" alt="image" src="https://user-images.githubusercontent.com/78121870/181600326-6e7ea16b-7ddb-49c4-b28c-8fe58649b73f.png">
## 참고사항
- 전 기울기와 현재 기울기를 곱해서 기울기가 같은 지 판단 
- 전 기울기가 음수인지 양수인지에 따라 분기처리 
- isToday에 해당하는 month 의 색깔을 category color로 변경 

||prev slope +|prev slope -|
|------|---|---|
|current slope + |왼쪽 위|아래|
|current slope - |위|오른쪽 위|





